### PR TITLE
feat(proveedor): migrar a UUID y mejorar gestión de proveedores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Registro de Cambios
+
+Este proyecto sigue el [Versionado Semántico](https://semver.org/).
+
+## [0.0.1-SNAPSHOT] - 2024-12-14
+
+### Agregado
+- Funcionalidad de cambio de contraseña
+- Mejoras en el sistema de logging
+
+## [0.0.0] - 2024-12-06
+
+### Cambiado
+- Actualización de dependencias:
+  - Spring Boot 3.4.0 → 3.5.3
+  - Spring Cloud 2024.0.0 → 2025.0.0
+  - SpringDoc OpenAPI 2.7.0 → 2.8.9
+
+## [0.0.0] - 2024-11-23
+
+### Agregado
+- Servicio común inicial
+- Configuraciones base del proyecto
+
+## [0.0.0] - 2024-09-19
+
+### Agregado
+- Funcionalidad de importación de Lista Iveco
+
+## [0.0.0] - 2024-08-12
+
+### Mejorado
+- Configuración de bootstrap.yml
+
+---
+
+*Nota: Las fechas y versiones se basan en el historial de git y el archivo pom.xml. Las versiones anteriores a 0.0.1-SNAPSHOT se marcan como 0.0.0 ya que no se pudo determinar el número de versión exacto en esos commits.*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
-# PyS.articulo-service
+# PyS Common Service
 
-[![PyS.articulo-service CI](https://github.com/PyS-services/PyS.articulo-service/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/PyS-services/PyS.articulo-service/actions/workflows/maven.yml)
+[![PyS Common Service CI](https://github.com/PyS-services/PyS.common-service/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/PyS-services/PyS.common-service/actions/workflows/maven.yml)
+
+Servicio común para la plataforma PyS que proporciona funcionalidades compartidas entre microservicios.
+
+## Tecnologías Principales
+
+- Java 21
+- Spring Boot 3.5.3
+- Spring Cloud 2025.0.0
+- SpringDoc OpenAPI 2.8.9
+- Apache POI 5.4.1
+- Kotlin 2.1.21
+
+## Características
+
+- Gestión de usuarios y autenticación
+- Funcionalidad de cambio de contraseña
+- Importación de datos (ej: Lista Iveco)
+- Documentación de API con OpenAPI
+
+## Requisitos
+
+- Java 21
+- Maven 3.9+
+- MySQL 8.0+
+- Eureka Server (para registro de servicios)

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.0</version>
+		<version>3.5.3</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.pys.common</groupId>
@@ -28,8 +28,8 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
-		<kotlin.version>2.1.0</kotlin.version>
-		<spring-cloud.version>2024.0.0</spring-cloud.version>
+		<kotlin.version>2.1.21</kotlin.version>
+		<spring-cloud.version>2025.0.0</spring-cloud.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -52,7 +52,6 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>com.mysql</groupId>
 			<artifactId>mysql-connector-j</artifactId>
@@ -71,17 +70,17 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.7.0</version>
+			<version>2.8.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>5.3.0</version>
+			<version>5.4.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
-			<version>5.3.0</version>
+			<version>5.4.1</version>
 		</dependency>
 
 		<dependency>
@@ -92,7 +91,22 @@
 			<groupId>com.fasterxml.jackson.module</groupId>
 			<artifactId>jackson-module-kotlin</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+		</dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-spring-boot-starter</artifactId>
+        </dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>
@@ -103,6 +117,13 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+            <dependency>
+                <groupId>io.opentelemetry.instrumentation</groupId>
+                <artifactId>opentelemetry-instrumentation-bom</artifactId>
+                <version>2.16.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/src/main/java/com/pys/common/java/controller/ArticuloAliasController.java
+++ b/src/main/java/com/pys/common/java/controller/ArticuloAliasController.java
@@ -1,0 +1,26 @@
+package com.pys.common.java.controller;
+
+import com.pys.common.java.service.ArticuloAliasService;
+import com.pys.common.kotlin.model.ArticuloAlias;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/common-service/articuloAlias")
+public class ArticuloAliasController {
+
+    private final ArticuloAliasService service;
+
+    public ArticuloAliasController(ArticuloAliasService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/addOrUpdate")
+    public ResponseEntity<ArticuloAlias> addOrUpdate(@RequestBody ArticuloAlias articuloAlias) {
+        return ResponseEntity.ok(service.addOrUpdate(articuloAlias));
+    }
+
+}

--- a/src/main/java/com/pys/common/java/controller/ArticuloController.java
+++ b/src/main/java/com/pys/common/java/controller/ArticuloController.java
@@ -1,10 +1,35 @@
 package com.pys.common.java.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.pys.common.java.service.ArticuloService;
+import com.pys.common.kotlin.exception.ArticuloException;
+import com.pys.common.kotlin.model.Articulo;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/common-service/articulo")
 public class ArticuloController {
+
+    private final ArticuloService service;
+
+    public ArticuloController(ArticuloService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/codigo/articulo/{codigoArticulo}")
+    public ResponseEntity<Articulo> findByCodigoArticulo(@PathVariable String codigoArticulo) {
+        try {
+            return ResponseEntity.ok(service.findByCodigoArticulo(codigoArticulo));
+        } catch (ArticuloException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
+    @PostMapping("/addOrUpdate")
+    public ResponseEntity<Articulo> addOrUpdate(@RequestBody Articulo articulo) {
+        return ResponseEntity.ok(service.addOrUpdate(articulo));
+    }
 
 }

--- a/src/main/java/com/pys/common/java/controller/CotizacionController.java
+++ b/src/main/java/com/pys/common/java/controller/CotizacionController.java
@@ -1,0 +1,30 @@
+package com.pys.common.java.controller;
+
+import com.pys.common.java.service.CotizacionService;
+import com.pys.common.kotlin.model.Cotizacion;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/common-service/cotizacion")
+public class CotizacionController {
+
+    private final CotizacionService service;
+
+    public CotizacionController(CotizacionService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/")
+    public ResponseEntity<List<Cotizacion>> findAll() {
+        return ResponseEntity.ok(service.findAll());
+    }
+
+    @PostMapping("/addOrUpdate")
+    public ResponseEntity<Cotizacion> addOrUpdate(@RequestBody Cotizacion cotizacion) {
+        return ResponseEntity.ok(service.addOrUpdate(cotizacion));
+    }
+
+}

--- a/src/main/java/com/pys/common/java/controller/ProveedorController.java
+++ b/src/main/java/com/pys/common/java/controller/ProveedorController.java
@@ -1,25 +1,113 @@
 package com.pys.common.java.controller;
 
 import com.pys.common.java.service.ProveedorService;
+import com.pys.common.kotlin.exception.ProveedorException;
 import com.pys.common.kotlin.model.Proveedor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
+import java.util.List;
+import java.util.UUID;
+
+@CrossOrigin(origins = "http://localhost:5173")
 @RestController
 @RequestMapping("/api/common-service/proveedor")
 public class ProveedorController {
 
-    private final ProveedorService proveedorService;
+    private final ProveedorService service;
 
-    public ProveedorController(ProveedorService proveedorService) {
-        this.proveedorService = proveedorService;
+    public ProveedorController(ProveedorService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/")
+    public ResponseEntity<List<Proveedor>> findAll() {
+        return ResponseEntity.ok(service.findAll());
+    }
+
+    @GetMapping("/page")
+    public ResponseEntity<Page<Proveedor>> findAllPaginated(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(service.findAllPaginated(pageable));
+    }
+
+    @GetMapping("/page/contains/{razonSocial}")
+    public ResponseEntity<Page<Proveedor>> findAllPaginatedContaining(
+            @PathVariable String razonSocial,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(service.findAllPaginatedContains(razonSocial, pageable));
+    }
+
+    @GetMapping("/search/{searchString}")
+    public ResponseEntity<List<Proveedor>> searchProveedores(@PathVariable String searchString) {
+        return ResponseEntity.ok(service.searchProveedores(searchString));
     }
 
     @GetMapping("/{proveedorId}")
-    public ResponseEntity<Proveedor> findByProveedorId(Long proveedorId) {
-        return ResponseEntity.ok(proveedorService.findByProveedorId(proveedorId));
+    public ResponseEntity<Proveedor> findByProveedorId(@PathVariable UUID proveedorId) {
+        try {
+            return ResponseEntity.ok(service.findByProveedorId(proveedorId));
+        } catch (ProveedorException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
+    @GetMapping("/negocio/{proveedorIdNegocio}")
+    public ResponseEntity<Proveedor> findByProveedorIdNegocio(@PathVariable Long proveedorIdNegocio) {
+        try {
+            return ResponseEntity.ok(service.findByProveedorIdNegocio(proveedorIdNegocio));
+        } catch (ProveedorException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
+    @GetMapping("/cuit/{cuit}")
+    public ResponseEntity<Proveedor> findByCuit(@PathVariable String cuit) {
+        try {
+            return ResponseEntity.ok(service.findByCuit(cuit));
+        } catch (ProveedorException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
+    @GetMapping("/last")
+    public ResponseEntity<Proveedor> findLastByProveedorIdNegocio() {
+        try {
+            return ResponseEntity.ok(service.findLastByProveedorIdNegocio());
+        } catch (ProveedorException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
+    @PostMapping("/")
+    public ResponseEntity<Proveedor> add(@RequestBody Proveedor proveedor) {
+        return ResponseEntity.ok(service.add(proveedor));
+    }
+
+    @PostMapping("/addOrUpdate")
+    public ResponseEntity<Proveedor> addOrUpdate(@RequestBody Proveedor proveedor) {
+        return ResponseEntity.ok(service.addOrUpdate(proveedor));
+    }
+
+    @PutMapping("/{proveedorId}")
+    public ResponseEntity<Proveedor> update(@PathVariable UUID proveedorId, @RequestBody Proveedor proveedor) {
+        return ResponseEntity.ok(service.updateByProveedorId(proveedor, proveedorId));
+    }
+
+    @DeleteMapping("/{proveedorId}")
+    public ResponseEntity<Void> delete(@PathVariable UUID proveedorId) {
+        service.deleteByProveedorId(proveedorId);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/com/pys/common/java/service/ArticuloAliasService.java
+++ b/src/main/java/com/pys/common/java/service/ArticuloAliasService.java
@@ -1,0 +1,59 @@
+package com.pys.common.java.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.pys.common.kotlin.exception.ArticuloAliasException;
+import com.pys.common.kotlin.model.ArticuloAlias;
+import com.pys.common.kotlin.repository.ArticuloAliasRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class ArticuloAliasService {
+
+    private final ArticuloAliasRepository repository;
+
+    public ArticuloAliasService(ArticuloAliasRepository repository) {
+        this.repository = repository;
+    }
+
+    public ArticuloAlias add(ArticuloAlias articuloAlias) {
+        log.debug("Processing request for add");
+        articuloAlias = repository.save(articuloAlias);
+        logArticuloAlias(articuloAlias);
+        return articuloAlias;
+    }
+
+    public ArticuloAlias update(ArticuloAlias newArticuloAlias, String alias) {
+        log.debug("Processing request for update");
+        return repository.findByAlias(alias).map(articuloAlias -> {
+            articuloAlias = new ArticuloAlias.Builder()
+                    .articuloAliasId(articuloAlias.getArticuloAliasId())
+                    .articuloId(newArticuloAlias.getArticuloId())
+                    .alias(newArticuloAlias.getAlias())
+                    .proveedorId(newArticuloAlias.getProveedorId())
+                    .precioCompra(newArticuloAlias.getPrecioCompra())
+                    .build();
+            articuloAlias = repository.save(articuloAlias);
+            logArticuloAlias(articuloAlias);
+            return articuloAlias;
+        }).orElseThrow(() -> new ArticuloAliasException(alias));
+    }
+
+    public ArticuloAlias addOrUpdate(ArticuloAlias articuloAlias) {
+        log.debug("Processing request for addOrUpdate");
+        return repository.findByAlias(articuloAlias.getAlias())
+                .map(existingArticuloAlias -> update(articuloAlias, articuloAlias.getAlias()))
+                .orElseGet(() -> add(articuloAlias));
+    }
+
+    private void logArticuloAlias(ArticuloAlias articuloAlias) {
+        try {
+            log.debug("ArticuloAlias -> {}", JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(articuloAlias));
+        } catch (JsonProcessingException e) {
+            log.error("ArticuloAlias jsonify error -> {}", e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/com/pys/common/java/service/ArticuloImportadoService.java
+++ b/src/main/java/com/pys/common/java/service/ArticuloImportadoService.java
@@ -19,4 +19,8 @@ public class ArticuloImportadoService {
         return repository.saveAll(articulosImported);
     }
 
+    public ArticuloImportado add(ArticuloImportado articuloImported) {
+        return repository.save(articuloImported);
+    }
+
 }

--- a/src/main/java/com/pys/common/java/service/ArticuloService.java
+++ b/src/main/java/com/pys/common/java/service/ArticuloService.java
@@ -1,13 +1,19 @@
 package com.pys.common.java.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.pys.common.kotlin.exception.ArticuloException;
 import com.pys.common.kotlin.model.Articulo;
 import com.pys.common.kotlin.repository.ArticuloRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
+@Slf4j
 public class ArticuloService {
 
     private final ArticuloRepository repository;
@@ -25,11 +31,68 @@ public class ArticuloService {
     }
 
     public Articulo findByCodigoArticulo(String codigoArticulo) {
-        return repository.findByCodigoArticulo(codigoArticulo).orElseThrow(() -> new ArticuloException(codigoArticulo));
+        log.debug("Processing request for findByCodigoArticulo");
+        Articulo articulo = repository.findByCodigoArticulo(codigoArticulo)
+                .orElseThrow(() -> new ArticuloException(codigoArticulo));
+        logArticulo(articulo);
+        return articulo;
     }
 
     public List<Articulo> saveAll(List<Articulo> articulos) {
         return repository.saveAll(articulos);
+    }
+
+    public Articulo add(Articulo articulo) {
+        log.debug("Processing request for add");
+        articulo = repository.save(articulo);
+        logArticulo(articulo);
+        return articulo;
+    }
+
+    public Articulo update(Articulo newArticulo, String codigoArticulo) {
+        log.debug("Processing request for update");
+        return repository.findByCodigoArticulo(codigoArticulo).map(articulo -> {
+            articulo = new Articulo.Builder()
+                    .articuloId(articulo.getArticuloId())
+                    .codigoArticulo(newArticulo.getCodigoArticulo())
+                    .descripcion(newArticulo.getDescripcion())
+                    .precioVentaConIva(newArticulo.getPrecioVentaConIva())
+                    .precioVentaSinIva(newArticulo.getPrecioVentaSinIva())
+                    .precioListaConIva(newArticulo.getPrecioListaConIva())
+                    .precioListaSinIva(newArticulo.getPrecioListaSinIva())
+                    .precioCompraSinIva(newArticulo.getPrecioCompraSinIva())
+                    .precioCompraSinIvaAnterior(newArticulo.getPrecioCompraSinIvaAnterior())
+                    .flagIva105(newArticulo.getFlagIva105())
+                    .flagExento(newArticulo.getFlagExento())
+                    .modeloCamion(newArticulo.getModeloCamion())
+                    .fechaActualizacion(newArticulo.getFechaActualizacion())
+                    .origen(newArticulo.getOrigen())
+                    .descuento(newArticulo.getDescuento())
+                    .proveedorId(newArticulo.getProveedorId())
+                    .ultimaCompra(newArticulo.getUltimaCompra())
+                    .marca(newArticulo.getMarca())
+                    .precioListaSinIvaUsd(newArticulo.getPrecioListaSinIvaUsd())
+                    .cotizacionId(newArticulo.getCotizacionId())
+                    .build();
+            articulo = repository.save(articulo);
+            logArticulo(articulo);
+            return articulo;
+        }).orElseThrow(() -> new ArticuloException(codigoArticulo));
+    }
+
+    public Articulo addOrUpdate(Articulo articulo) {
+        log.debug("Processing request for addOrUpdate");
+        return repository.findByCodigoArticulo(articulo.getCodigoArticulo())
+                .map(existingArticulo -> update(articulo, articulo.getCodigoArticulo()))
+                .orElseGet(() -> add(articulo));
+    }
+
+    private void logArticulo(Articulo articulo) {
+        try {
+            log.debug("Articulo -> {}", JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(articulo));
+        } catch (JsonProcessingException e) {
+            log.error("Articulo jsonify error -> {}", e.getMessage());
+        }
     }
 
 }

--- a/src/main/java/com/pys/common/java/service/CotizacionService.java
+++ b/src/main/java/com/pys/common/java/service/CotizacionService.java
@@ -1,13 +1,19 @@
 package com.pys.common.java.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.pys.common.kotlin.exception.CotizacionException;
 import com.pys.common.kotlin.model.Cotizacion;
 import com.pys.common.kotlin.repository.CotizacionRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Objects;
 
 @Service
+@Slf4j
 public class CotizacionService {
 
     private final CotizacionRepository repository;
@@ -16,12 +22,50 @@ public class CotizacionService {
         this.repository = repository;
     }
 
-    public Cotizacion findByFecha(OffsetDateTime fechaImportacion) {
-        return repository.findByFecha(fechaImportacion).orElseThrow(() -> new CotizacionException(fechaImportacion));
+    public List<Cotizacion> findAll() {
+        return repository.findAll();
     }
 
-    public Cotizacion save(Cotizacion cotizacion) {
-        return repository.save(cotizacion);
+    public Cotizacion findByFecha(OffsetDateTime fecha) {
+        log.debug("Processing cotizacion for findByFecha");
+        return Objects.requireNonNull(repository.findByFecha(fecha)).orElseThrow(() -> new CotizacionException(fecha));
+    }
+
+    public Cotizacion add(Cotizacion cotizacion) {
+        log.debug("Processing cotizacion for add");
+        logCotizacion(cotizacion);
+        cotizacion = repository.save(cotizacion);
+        logCotizacion(cotizacion);
+        return cotizacion;
+    }
+
+    public Cotizacion update(Cotizacion cotizacion, OffsetDateTime fecha) {
+        log.debug("Processing cotizacion for update");
+        return repository.findByFecha(fecha).map(existingCotizacion -> {
+            existingCotizacion = new Cotizacion.Builder()
+                    .cotizacionId(existingCotizacion.getCotizacionId())
+                    .fecha(cotizacion.getFecha())
+                    .usdCompra(cotizacion.getUsdCompra())
+                    .usdVenta(cotizacion.getUsdVenta())
+                    .build();
+            existingCotizacion = repository.save(existingCotizacion);
+            logCotizacion(existingCotizacion);
+            return existingCotizacion;
+        }).orElseThrow(() -> new CotizacionException(fecha));
+    }
+
+    public Cotizacion addOrUpdate(Cotizacion cotizacion) {
+        log.debug("Processing cotizacion for addOrUpdate");
+        return repository.findByFecha(Objects.requireNonNull(cotizacion.getFecha())).map(existingCotizacion -> update(cotizacion, cotizacion.getFecha()))
+                .orElseGet(() -> add(cotizacion));
+    }
+
+    private void logCotizacion(Cotizacion cotizacion) {
+        try {
+            log.debug("Cotizacion -> {}", JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(cotizacion));
+        } catch (JsonProcessingException e) {
+            log.error("Cotizacion jsonify error -> {}", e.getMessage());
+        }
     }
 
 }

--- a/src/main/java/com/pys/common/java/service/ProveedorService.java
+++ b/src/main/java/com/pys/common/java/service/ProveedorService.java
@@ -1,11 +1,24 @@
 package com.pys.common.java.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.pys.common.kotlin.exception.ProveedorException;
 import com.pys.common.kotlin.model.Proveedor;
 import com.pys.common.kotlin.repository.ProveedorRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.springframework.data.domain.PageRequest;
+import static com.pys.common.java.specification.ProveedorSpecifications.searchByCadena;
 
 @Service
+@Slf4j
 public class ProveedorService {
 
     private final ProveedorRepository repository;
@@ -14,7 +27,122 @@ public class ProveedorService {
         this.repository = repository;
     }
 
-    public Proveedor findByProveedorId(Long proveedorId) {
-        return repository.findByProveedorId(proveedorId).orElseThrow(() -> new ProveedorException(proveedorId));
+    public List<Proveedor> findAll() {
+        return repository.findAllByOrderByRazonSocial();
     }
+
+    public Page<Proveedor> findAllPaginated(Pageable pageable) {
+        return repository.findAllByOrderByRazonSocial(pageable);
+    }
+
+    public Page<Proveedor> findAllPaginatedContains(String razonSocial, Pageable pageable) {
+        return repository.findAllByRazonSocialContainsIgnoreCaseOrderByRazonSocial(razonSocial, pageable);
+    }
+
+    public List<Proveedor> searchProveedores(String searchString) {
+        return repository.findAll(
+            searchByCadena(searchString), 
+            PageRequest.of(0, 50, Sort.by("razonSocial").ascending())
+        ).getContent();
+    }
+
+    public Proveedor findByProveedorId(UUID proveedorId) {
+        return Objects.requireNonNull(repository.findByProveedorId(proveedorId)).orElseThrow(() -> new ProveedorException(proveedorId));
+    }
+
+    public Proveedor findByProveedorIdNegocio(Long proveedorIdNegocio) {
+        return Objects.requireNonNull(repository.findByProveedorIdNegocio(proveedorIdNegocio)).orElseThrow(() -> new ProveedorException(proveedorIdNegocio));
+    }
+
+    public Proveedor findByCuit(String cuit) {
+        return Objects.requireNonNull(repository.findByCuit(cuit)).orElseThrow(() -> new ProveedorException(cuit));
+    }
+
+    public Proveedor findLastByProveedorIdNegocio() {
+        return Objects.requireNonNull(repository.findTop1ByOrderByProveedorIdNegocioDesc()).orElseThrow(ProveedorException::new);
+    }
+
+    public Proveedor add(Proveedor proveedor) {
+        log.debug("Processing proveedor for add");
+        if (proveedor.getProveedorIdNegocio() == null || proveedor.getProveedorIdNegocio() == 0) {
+            proveedor.setProveedorIdNegocio(findLastByProveedorIdNegocio().getProveedorIdNegocio() + 1);
+        }
+        proveedor = repository.save(proveedor);
+        logProveedor(proveedor);
+        return proveedor;
+    }
+
+    public Proveedor updateByProveedorId(Proveedor proveedor, UUID proveedorId) {
+        log.debug("Processing proveedor for update");
+        return repository.findByProveedorId(proveedorId).map(existingProveedor -> {
+            existingProveedor = new Proveedor.Builder()
+                    .proveedorId(existingProveedor.getProveedorId())
+                    .proveedorIdNegocio(proveedor.getProveedorIdNegocio())
+                    .razonSocial(proveedor.getRazonSocial())
+                    .nombreFantasia(proveedor.getNombreFantasia())
+                    .cuit(proveedor.getCuit())
+                    .domicilio(proveedor.getDomicilio())
+                    .localidad(proveedor.getLocalidad())
+                    .provincia(proveedor.getProvincia())
+                    .telefono(proveedor.getTelefono())
+                    .fax(proveedor.getFax())
+                    .email(proveedor.getEmail())
+                    .posicionIva(proveedor.getPosicionIva())
+                    .celular(proveedor.getCelular())
+                    .ingresosBrutos(proveedor.getIngresosBrutos())
+                    .contacto(proveedor.getContacto())
+                    .observaciones(proveedor.getObservaciones())
+                    .build();
+            existingProveedor = repository.save(existingProveedor);
+            logProveedor(existingProveedor);
+            return existingProveedor;
+        }).orElseThrow(() -> new ProveedorException(proveedorId));
+    }
+
+    public Proveedor updateByProveedorIdNegocio(Proveedor proveedor, Long proveedorIdNegocio) {
+        log.debug("Processing proveedor for update");
+        return repository.findByProveedorIdNegocio(proveedorIdNegocio).map(existingProveedor -> {
+            existingProveedor = new Proveedor.Builder()
+                    .proveedorId(existingProveedor.getProveedorId())
+                    .proveedorIdNegocio(proveedor.getProveedorIdNegocio())
+                    .razonSocial(proveedor.getRazonSocial())
+                    .nombreFantasia(proveedor.getNombreFantasia())
+                    .cuit(proveedor.getCuit())
+                    .domicilio(proveedor.getDomicilio())
+                    .localidad(proveedor.getLocalidad())
+                    .provincia(proveedor.getProvincia())
+                    .telefono(proveedor.getTelefono())
+                    .fax(proveedor.getFax())
+                    .email(proveedor.getEmail())
+                    .posicionIva(proveedor.getPosicionIva())
+                    .celular(proveedor.getCelular())
+                    .ingresosBrutos(proveedor.getIngresosBrutos())
+                    .contacto(proveedor.getContacto())
+                    .observaciones(proveedor.getObservaciones())
+                    .build();
+            existingProveedor = repository.save(existingProveedor);
+            logProveedor(existingProveedor);
+            return existingProveedor;
+        }).orElseThrow(() -> new ProveedorException(proveedorIdNegocio));
+    }
+
+    public Proveedor addOrUpdate(Proveedor proveedor) {
+        log.debug("Processing proveedor for addOrUpdate");
+        return repository.findByProveedorIdNegocio(Objects.requireNonNull(proveedor.getProveedorIdNegocio())).map(existingProveedor -> updateByProveedorIdNegocio(proveedor, proveedor.getProveedorIdNegocio()))
+                .orElseGet(() -> add(proveedor));
+    }
+
+    private void logProveedor(Proveedor proveedor) {
+        try {
+            log.debug("Proveedor -> {}", JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(proveedor));
+        } catch (JsonProcessingException e) {
+            log.error("Proveedor jsonify error -> {}", e.getMessage());
+        }
+    }
+
+    @Transactional
+    public void deleteByProveedorId(UUID proveedorId) {
+        repository.deleteByProveedorId(proveedorId);
+    }
+
 }

--- a/src/main/java/com/pys/common/java/service/excel/ExcelProcessor.java
+++ b/src/main/java/com/pys/common/java/service/excel/ExcelProcessor.java
@@ -1,0 +1,157 @@
+package com.pys.common.java.service.excel;
+
+import com.pys.common.kotlin.model.Articulo;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Component;
+
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.*;
+
+@Slf4j
+@Component
+public class ExcelProcessor {
+    private static final int HEADER_ROW_INDEX = 4;
+    private static final int STARTING_ROW = 5;
+    private static final List<String> REQUIRED_COLUMNS = Arrays.asList(
+            "catalogo", "origen", "sinIva", "descuento", 
+            "denominacion", "fecha", "modelo"
+    );
+
+    public List<Articulo> processExcelFile(InputStream inputStream, BigDecimal cotizacionDolar) throws Exception {
+        try (Workbook workbook = new XSSFWorkbook(inputStream)) {
+            Sheet sheet = workbook.getSheetAt(0);
+            Map<String, Integer> columnMap = getColumnIndexMap(sheet);
+            validateRequiredColumns(columnMap);
+            return processRows(sheet, columnMap, cotizacionDolar);
+        }
+    }
+
+    private Map<String, Integer> getColumnIndexMap(Sheet sheet) {
+        Row headerRow = Optional.ofNullable(sheet.getRow(HEADER_ROW_INDEX))
+                .orElseThrow(() -> new IllegalStateException("Header row not found"));
+
+        Map<String, Integer> columnMap = new HashMap<>();
+        headerRow.forEach(cell -> {
+            String cellValue = getCellValueAsString(cell);
+            mapColumnHeader(cellValue, cell.getColumnIndex(), columnMap);
+        });
+
+        return columnMap;
+    }
+
+    private void mapColumnHeader(String cellValue, int columnIndex, Map<String, Integer> columnMap) {
+        switch (cellValue) {
+            case "Catálogo" -> columnMap.put("catalogo", columnIndex);
+            case "0" -> columnMap.put("origen", columnIndex);
+            case "s/IVA" -> columnMap.put("sinIva", columnIndex);
+            case "D" -> columnMap.put("descuento", columnIndex);
+            case "Denominación" -> columnMap.put("denominacion", columnIndex);
+            case "Fecha" -> columnMap.put("fecha", columnIndex);
+            case "Modelo" -> columnMap.put("modelo", columnIndex);
+        }
+    }
+
+    private void validateRequiredColumns(Map<String, Integer> columnMap) {
+        Set<String> missingColumns = new HashSet<>();
+        REQUIRED_COLUMNS.forEach(column -> {
+            if (!columnMap.containsKey(column)) {
+                missingColumns.add(column);
+            }
+        });
+
+        if (!missingColumns.isEmpty()) {
+            throw new IllegalStateException("Missing required columns: " + missingColumns);
+        }
+    }
+
+    private List<Articulo> processRows(Sheet sheet, Map<String, Integer> columnMap, BigDecimal cotizacionDolar) {
+        List<Articulo> articulos = new ArrayList<>();
+        int lastRowNum = sheet.getLastRowNum();
+
+        for (int rowIndex = STARTING_ROW; rowIndex <= lastRowNum; rowIndex++) {
+            Row row = sheet.getRow(rowIndex);
+            if (isRowEmpty(row)) continue;
+
+            try {
+                Articulo articulo = processRow(row, columnMap, cotizacionDolar);
+                articulos.add(articulo);
+            } catch (Exception e) {
+                log.warn("Error processing row {}: {}", rowIndex + 1, e.getMessage());
+            }
+        }
+
+        return articulos;
+    }
+
+    private boolean isRowEmpty(Row row) {
+        return row == null || row.getPhysicalNumberOfCells() == 0;
+    }
+
+    private Articulo processRow(Row row, Map<String, Integer> columnMap, BigDecimal cotizacionDolar) {
+        BigDecimal sinIvaUsd = getCellValueAsBigDecimal(row.getCell(columnMap.get("sinIva")));
+        BigDecimal precioListaSinIva = sinIvaUsd.multiply(cotizacionDolar)
+                .setScale(2, RoundingMode.HALF_UP);
+
+        return new Articulo.Builder()
+                .codigoArticulo(getCellValueAsString(row.getCell(columnMap.get("catalogo"))).trim() + ".I")
+                .descripcion(cleanGarbage(getCellValueAsString(row.getCell(columnMap.get("denominacion"))).trim()))
+                .precioListaSinIvaUsd(sinIvaUsd)
+                .precioListaSinIva(precioListaSinIva)
+                .origen(getCellValueAsString(row.getCell(columnMap.get("origen"))))
+                .descuento(getCellValueAsString(row.getCell(columnMap.get("descuento"))).trim())
+                .fechaActualizacion(getCellValueAsOffsetDateTime(row.getCell(columnMap.get("fecha"))))
+                .modeloCamion(getCellValueAsString(row.getCell(columnMap.get("modelo"))).trim())
+                .build();
+    }
+
+    private String getCellValueAsString(Cell cell) {
+        if (cell == null) return "";
+        
+        return switch (cell.getCellType()) {
+            case STRING -> cell.getStringCellValue();
+            case NUMERIC -> {
+                if (DateUtil.isCellDateFormatted(cell)) {
+                    yield cell.getDateCellValue().toString();
+                }
+                yield BigDecimal.valueOf(cell.getNumericCellValue()).toPlainString();
+            }
+            case BOOLEAN -> Boolean.toString(cell.getBooleanCellValue());
+            case FORMULA -> cell.getCellFormula();
+            default -> "";
+        };
+    }
+
+    private BigDecimal getCellValueAsBigDecimal(Cell cell) {
+        if (cell == null) return BigDecimal.ZERO;
+        
+        return switch (cell.getCellType()) {
+            case NUMERIC -> BigDecimal.valueOf(cell.getNumericCellValue());
+            case STRING -> {
+                try {
+                    yield new BigDecimal(cell.getStringCellValue().replace(",", ".").trim());
+                } catch (NumberFormatException e) {
+                    yield BigDecimal.ZERO;
+                }
+            }
+            default -> BigDecimal.ZERO;
+        };
+    }
+
+    private OffsetDateTime getCellValueAsOffsetDateTime(Cell cell) {
+        if (cell == null) return null;
+        if (cell.getCellType() == CellType.NUMERIC && DateUtil.isCellDateFormatted(cell)) {
+            return cell.getDateCellValue().toInstant().atOffset(ZoneOffset.UTC);
+        }
+        return null;
+    }
+
+    private String cleanGarbage(String input) {
+        return input.replaceAll("[^\\p{Print}]", "");
+    }
+} 

--- a/src/main/java/com/pys/common/java/service/facade/ImportListaIvecoService.java
+++ b/src/main/java/com/pys/common/java/service/facade/ImportListaIvecoService.java
@@ -3,18 +3,14 @@ package com.pys.common.java.service.facade;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.pys.common.java.service.*;
+import com.pys.common.java.service.excel.ExcelProcessor;
 import com.pys.common.java.service.facade.status.ProcessStatus;
 import com.pys.common.kotlin.exception.CotizacionException;
-import com.pys.common.kotlin.model.Articulo;
-import com.pys.common.kotlin.model.ArticuloImportado;
-import com.pys.common.kotlin.model.Cotizacion;
-import com.pys.common.kotlin.model.Importacion;
-import jakarta.transaction.Transactional;
+import com.pys.common.kotlin.model.*;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.poi.ss.usermodel.*;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -25,7 +21,10 @@ import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Service
 @Slf4j
@@ -39,13 +38,32 @@ public class ImportListaIvecoService {
     private final ArticuloService articuloService;
     private final ProveedorService proveedorService;
     private final ArticuloImportadoService articuloImportadoService;
+    private final ExcelProcessor excelProcessor;
 
-    public ImportListaIvecoService(ImportacionService importacionService, CotizacionService cotizacionService, ArticuloService articuloService, ProveedorService proveedorService, ArticuloImportadoService articuloImportadoService) {
+    // Al inicio de la clase, define un JsonMapper thread-safe
+    private static final JsonMapper JSON_MAPPER = JsonMapper.builder()
+        .findAndAddModules()
+        .build();
+
+    private static final int BATCH_SIZE = 1000;  // Aumentado de 500 a 1000
+
+    private static final Map<String, BigDecimal> PRECIO_VENTA_DESCUENTOS = Map.of(
+        "A", BigDecimal.ZERO,
+        "9", BigDecimal.ZERO,
+        "S", BigDecimal.ZERO,
+        "7", BigDecimal.ZERO,
+        "C", BigDecimal.ZERO,
+        "6", BigDecimal.ZERO,
+        "DEFAULT", BigDecimal.valueOf(0.10)
+    );
+
+    public ImportListaIvecoService(ImportacionService importacionService, CotizacionService cotizacionService, ArticuloService articuloService, ProveedorService proveedorService, ArticuloImportadoService articuloImportadoService, ExcelProcessor excelProcessor) {
         this.importacionService = importacionService;
         this.cotizacionService = cotizacionService;
         this.articuloService = articuloService;
         this.proveedorService = proveedorService;
         this.articuloImportadoService = articuloImportadoService;
+        this.excelProcessor = excelProcessor;
     }
 
     public String generateProcessId() {
@@ -57,7 +75,6 @@ public class ImportListaIvecoService {
     }
 
     @Async
-    @Transactional
     public void processFileAsync(byte[] fileContent, String processId, String cotizacionDolarString) {
         try {
             // Almacena el estado inicial del procesamiento
@@ -77,112 +94,125 @@ public class ImportListaIvecoService {
             }
 
             // Registro de inicio de procesamiento
-            log.debug("Procesando archivo con cotización: " + cotizacionDolar);
+            log.debug("Procesando archivo con cotización: {}", cotizacionDolar);
 
             var importacion = new Importacion.Builder()
                     .fechaImportacion(OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.DAYS))
                     .build();
 
             importacion = importacionService.add(importacion);
+            logImportacion(importacion);
 
-            try {
-                log.debug("Importacion -> {}", JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(importacion));
-            } catch (JsonProcessingException e) {
-                log.error("Importacion -> {}", e.getMessage());
-            }
+            Optional<Cotizacion> cotizacionOptional = findOrCreateCotizacion(importacion.getFechaImportacion(), cotizacionDolar);
+            Cotizacion cotizacion = cotizacionOptional.orElseThrow();
+            logCotizacion(cotizacion);
 
-            Cotizacion cotizacion = null;
-            try {
-                cotizacion = cotizacionService.findByFecha(importacion.getFechaImportacion());
-            } catch (CotizacionException e) {
-                cotizacion = new Cotizacion.Builder()
-                        .fecha(importacion.getFechaImportacion())
-                        .build();
-            }
-
-            cotizacion.setUsdVenta(cotizacionDolar);
-            cotizacion = cotizacionService.save(cotizacion);
-            try {
-                log.debug("Cotizacion -> {}", JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(cotizacion));
-            } catch (JsonProcessingException e) {
-                log.error("Cotizacion -> {}", e.getMessage());
-            }
-
-            var proveedor = proveedorService.findByProveedorId(1L);
-            try {
-                log.debug("Proveedor -> {}", JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(proveedor));
-            } catch (JsonProcessingException e) {
-                log.error("Proveedor -> {}", e.getMessage());
-            }
+            var proveedor = proveedorService.findByProveedorIdNegocio(1L);
+            logProveedor(proveedor);
 
             // Procesar el archivo Excel
             InputStream inputStream = new ByteArrayInputStream(fileContent);
-            List<Articulo> articulosFile = processExcelFile(inputStream, cotizacionDolar);
+            List<Articulo> articulosFile = excelProcessor.processExcelFile(inputStream, cotizacionDolar);
             List<String> codigoArticulos = articulosFile.stream().map(Articulo::getCodigoArticulo).toList();
             Map<String, Articulo> articulos = articuloService.findAllByCodigos(codigoArticulos).stream().collect(Collectors.toMap(Articulo::getCodigoArticulo, articulo -> articulo));
 
-            Map<String, Articulo> articulosToSave = new HashMap<>();
-            List<ArticuloImportado> articulosImported = new ArrayList<>();
-
+            // Usar AtomicInteger para el seguimiento del progreso de forma thread-safe
+            AtomicInteger articulosProcesados = new AtomicInteger(0);
             int totalArticulos = articulosFile.size();
-            int articulosProcesados = 0;
-            for (Articulo articuloFile : articulosFile) {
-                Articulo articulo = null;
-                if (articulos.containsKey(articuloFile.getCodigoArticulo())) {
-                    articulo = articulos.get(articuloFile.getCodigoArticulo());
-                    articulo.setDescripcion(articuloFile.getDescripcion());
-                    articulo.setPrecioListaSinIva(articuloFile.getPrecioListaSinIva());
-                    articulo.setPrecioListaSinIvaUsd(articuloFile.getPrecioListaSinIvaUsd());
-                    articulo.setOrigen(articuloFile.getOrigen());
-                    articulo.setDescuento(articuloFile.getDescuento());
-                    articulo.setFechaActualizacion(articuloFile.getFechaActualizacion());
-                    articulo.setModeloCamion(articuloFile.getModeloCamion());
-                    articulo.setCotizacionId(cotizacion.getCotizacionId());
-                    articulo.setProveedorId(proveedor.getProveedorId());
-                } else {
-                    articulo = new Articulo.Builder()
-                            .codigoArticulo(articuloFile.getCodigoArticulo().toUpperCase())
-                            .descripcion(articuloFile.getDescripcion())
-                            .precioListaSinIva(articuloFile.getPrecioListaSinIva())
-                            .precioListaSinIvaUsd(articuloFile.getPrecioListaSinIvaUsd())
-                            .origen(articuloFile.getOrigen())
-                            .descuento(articuloFile.getDescuento())
-                            .fechaActualizacion(articuloFile.getFechaActualizacion())
-                            .modeloCamion(articuloFile.getModeloCamion())
-                            .cotizacionId(cotizacion.getCotizacionId())
-                            .proveedorId(proveedor.getProveedorId())
-                            .build();
-                }
-                recalcularPrecios(articulo);
+            
+            // Optimizar el procesamiento por lotes usando partitioningBy
+            List<List<Articulo>> batches = IntStream.range(0, articulosFile.size())
+                .boxed()
+                .collect(Collectors.groupingBy(index -> index / BATCH_SIZE))
+                .values()
+                .stream()
+                .map(indices -> indices.stream()
+                    .map(articulosFile::get)
+                    .collect(Collectors.toList()))
+                .toList();
 
-                if (!articulosToSave.containsKey(articulo.getCodigoArticulo())) {
-                    articulosToSave.put(articulo.getCodigoArticulo(), articulo);
-                    var articuloImported = new ArticuloImportado.Builder()
-                            .articuloId(articulo.getArticuloId())
-                            .fecha(importacion.getFechaImportacion())
-                            .codigoArticulo(articulo.getCodigoArticulo())
-                            .descripcion(articulo.getDescripcion())
-                            .precioListaSinIva(articulo.getPrecioListaSinIva())
-                            .origen(articulo.getOrigen())
-                            .descuento(articulo.getDescuento())
-                            .fechaActualizacion(articulo.getFechaActualizacion())
-                            .cotizacionId(cotizacion.getCotizacionId())
-                            .valorUsd(cotizacionDolar)
-                            .importacionId(importacion.getImportacionId())
-                            .build();
-                    articulosImported.add(articuloImported);
-                }
+            // Procesar los lotes en paralelo
+            for (int counter = 0; counter < batches.size(); counter++) {
+                List<Articulo> batch = batches.get(counter);
+                List<Articulo> articulosSaved = new ArrayList<>();
+                List<ArticuloImportado> articulosImportadosToSave = new ArrayList<>();
+                
+                // Procesar el lote
+                Importacion finalImportacion = importacion;
+                batch.forEach(articuloFile -> {
+                    try {
+                        Articulo articulo = null;
+                        var isArticuloNew = false;
+                        
+                        if (articulos.containsKey(articuloFile.getCodigoArticulo())) {
+                            articulo = articulos.get(articuloFile.getCodigoArticulo());
+                            articulo.setDescripcion(articuloFile.getDescripcion());
+                            articulo.setPrecioListaSinIva(articuloFile.getPrecioListaSinIva());
+                            articulo.setPrecioListaSinIvaUsd(articuloFile.getPrecioListaSinIvaUsd());
+                            articulo.setOrigen(articuloFile.getOrigen());
+                            articulo.setDescuento(articuloFile.getDescuento());
+                            articulo.setFechaActualizacion(articuloFile.getFechaActualizacion());
+                            articulo.setModeloCamion(articuloFile.getModeloCamion());
+                            articulo.setCotizacionId(cotizacion.getCotizacionId());
+                            articulo.setProveedorId(proveedor.getProveedorId());
+                            log.debug("Articulo actualizado");
+                        } else {
+                            articulo = new Articulo.Builder()
+                                    .codigoArticulo(articuloFile.getCodigoArticulo().toUpperCase())
+                                    .descripcion(articuloFile.getDescripcion())
+                                    .precioListaSinIva(articuloFile.getPrecioListaSinIva())
+                                    .precioListaSinIvaUsd(articuloFile.getPrecioListaSinIvaUsd())
+                                    .origen(articuloFile.getOrigen())
+                                    .descuento(articuloFile.getDescuento())
+                                    .fechaActualizacion(articuloFile.getFechaActualizacion())
+                                    .modeloCamion(articuloFile.getModeloCamion())
+                                    .cotizacionId(cotizacion.getCotizacionId())
+                                    .proveedorId(proveedor.getProveedorId())
+                                    .build();
+                            isArticuloNew = true;
+                            log.debug("Articulo creado");
+                        }
+
+                        // Recalcular precios
+                        recalcularPrecios(articulo);
+                        articulo = isArticuloNew ? articuloService.add(articulo) : articuloService.update(articulo, articulo.getCodigoArticulo());
+                        articulosSaved.add(articulo);
+
+                    } catch (Exception e) {
+                        log.error("Error procesando artículo en lote: {}", e.getMessage());
+                    }
+                });
+
+                // Crear y guardar todos los ArticuloImportado del batch
+                articulosSaved.forEach(articulo -> {
+                    var articuloImported = createArticuloImportado(articulo, finalImportacion, cotizacion, cotizacionDolar);
+                    articulosImportadosToSave.add(articuloImported);
+                });
+                
+                articuloImportadoService.saveAll(articulosImportadosToSave);
+
                 // Actualizar progreso
-                articulosProcesados++;
-                int progress = (int) ((articulosProcesados / (double) totalArticulos) * 100);
-                log.debug("Progreso: {}", progress);
-                processingStatus.get(processId).setProgress(progress);
+                int articulosProcesadosEnBatch = batch.size();
+                synchronized(processingStatus) {
+                    int totalProcesados = articulosProcesados.addAndGet(articulosProcesadosEnBatch);
+                    int progress = (int) ((totalProcesados / (double) totalArticulos) * 100);
+                    ProcessStatus currentStatus = processingStatus.get(processId);
+                    if (currentStatus != null) {
+                        currentStatus.setStatus("En Progreso");
+                        currentStatus.setProgress(progress);
+                        log.debug("Procesado lote {}/{}, progreso: {}%", 
+                                counter + 1,
+                                batches.size(), 
+                                progress);
+                    }
+                }
+
+                // Opcional: agregar una pequeña pausa entre lotes
+                Thread.sleep(50);
             }
 
-            articuloService.saveAll(articulosToSave.values().stream().toList());
-            articuloImportadoService.saveAll(articulosImported);
-
             // Actualiza el estado a 'Completado' después de procesar
+            log.debug("Actualizando estado a 'Completado' para el proceso {}", processId);
             processingStatus.get(processId).setStatus("Completado");
             processingStatus.get(processId).setProgress(100);
         } catch (Exception e) {
@@ -192,27 +222,63 @@ public class ImportListaIvecoService {
         }
     }
 
-    private void recalcularPrecios(Articulo articulo) {
+    private void logArticulo(Articulo articulo) {
+        try {
+            // Usa el mapper thread-safe
+            log.debug("Articulo -> {}", JSON_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(articulo));
+        } catch (JsonProcessingException e) {
+            log.error("Articulo jsonify error -> {}", e.getMessage());
+        }
+    }
 
+    private void logArticuloImportado(ArticuloImportado articuloImported) {
+        try {
+            log.debug("ArticuloImportado -> {}", JSON_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(articuloImported));
+        } catch (JsonProcessingException e) {
+            log.error("ArticuloImportado jsonify error -> {}", e.getMessage());
+        }
+    }
+
+    private void logProveedor(Proveedor proveedor) {
+        try {
+            log.debug("Proveedor -> {}", JSON_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(proveedor));
+        } catch (JsonProcessingException e) {
+            log.error("Proveedor jsonify error -> {}", e.getMessage());
+        }
+    }
+
+    private void logCotizacion(Cotizacion cotizacion) {
+        try {
+            log.debug("Cotizacion -> {}", JSON_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(cotizacion));
+        } catch (JsonProcessingException e) {
+            log.error("Cotizacion jsonify error -> {}", e.getMessage());
+        }
+    }
+
+    private void logImportacion(Importacion importacion) {
+        try {
+            log.debug("Importacion -> {}", JSON_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(importacion));
+        } catch (JsonProcessingException e) {
+            log.error("Importacion jsonify error -> {}", e.getMessage());
+        }
+    }
+
+    private static final Map<String, BigDecimal> DESCUENTOS_MAP = Map.of(
+            "A", Constants.DESCUENTO_NIVEL_1,
+            "9", Constants.DESCUENTO_NIVEL_1,
+            "S", Constants.DESCUENTO_NIVEL_2,
+            "7", Constants.DESCUENTO_NIVEL_2,
+            "C", Constants.DESCUENTO_NIVEL_3,
+            "6", Constants.DESCUENTO_NIVEL_3
+    );
+
+    private void recalcularPrecios(Articulo articulo) {
         // Cálculo de precios iniciales
-        BigDecimal precioListaConIva = a2Decimales(articulo.getPrecioListaSinIva().multiply(BigDecimal.valueOf(1.21)));
+        BigDecimal precioListaConIva = a2Decimales(articulo.getPrecioListaSinIva().multiply(Constants.IVA));
         articulo.setPrecioListaConIva(precioListaConIva);
 
-        articulo.setPrecioVentaConIva(a2Decimales(precioListaConIva));
-        articulo.setPrecioVentaSinIva(a2Decimales(articulo.getPrecioListaSinIva()));
-
         // Determina precio de compra
-        BigDecimal porcentajeDescuento = BigDecimal.valueOf(0.25);
-        String descuento = articulo.getDescuento();
-
-        if ("A".equals(descuento) || "9".equals(descuento)) {
-            porcentajeDescuento = BigDecimal.valueOf(0.05);
-        } else if ("S".equals(descuento) || "7".equals(descuento)) {
-            porcentajeDescuento = BigDecimal.valueOf(0.10);
-        } else if ("C".equals(descuento) || "6".equals(descuento)) {
-            porcentajeDescuento = BigDecimal.valueOf(0.12);
-        }
-
+        BigDecimal porcentajeDescuento = DESCUENTOS_MAP.getOrDefault(articulo.getDescuento(), Constants.DESCUENTO_DEFAULT);
         BigDecimal precioCompraSinIva = a2Decimales(
                 articulo.getPrecioVentaSinIva().multiply(BigDecimal.ONE.subtract(porcentajeDescuento))
         );
@@ -221,9 +287,9 @@ public class ImportListaIvecoService {
         // Determina precio de venta
         porcentajeDescuento = BigDecimal.valueOf(0.10);
 
-        if ("A".equals(descuento) || "9".equals(descuento) ||
-                "S".equals(descuento) || "7".equals(descuento) ||
-                "C".equals(descuento) || "6".equals(descuento)) {
+        if ("A".equals(articulo.getDescuento()) || "9".equals(articulo.getDescuento()) ||
+                "S".equals(articulo.getDescuento()) || "7".equals(articulo.getDescuento()) ||
+                "C".equals(articulo.getDescuento()) || "6".equals(articulo.getDescuento())) {
             porcentajeDescuento = BigDecimal.ZERO;
         }
 
@@ -236,172 +302,53 @@ public class ImportListaIvecoService {
                 articulo.getPrecioListaSinIva().multiply(BigDecimal.ONE.subtract(porcentajeDescuento))
         );
         articulo.setPrecioVentaSinIva(precioVentaSinIva);
-
     }
 
     private BigDecimal a2Decimales(BigDecimal value) {
         return value.setScale(2, RoundingMode.HALF_UP);
     }
 
-    private List<Articulo> processExcelFile(InputStream inputStream, BigDecimal cotizacionDolar) throws Exception {
-        List<Articulo> articulos = new ArrayList<>();
+    private static final class Constants {
+        static final BigDecimal IVA = BigDecimal.valueOf(1.21);
+        static final BigDecimal DESCUENTO_DEFAULT = BigDecimal.valueOf(0.25);
+        static final BigDecimal DESCUENTO_NIVEL_1 = BigDecimal.valueOf(0.05);
+        static final BigDecimal DESCUENTO_NIVEL_2 = BigDecimal.valueOf(0.10);
+        static final BigDecimal DESCUENTO_NIVEL_3 = BigDecimal.valueOf(0.12);
 
-        Workbook workbook = new XSSFWorkbook(inputStream);
-        Sheet sheet = workbook.getSheetAt(0);
-
-        int headerRowIndex = 4; // Índice de la fila que contiene la cabecera (fila 5 en Excel)
-        int startingRow = 5;    // Índice de la fila desde donde comenzar a procesar (fila 6 en Excel)
-
-        // Obtener la fila de la cabecera
-        Row headerRow = sheet.getRow(headerRowIndex);
-        if (headerRow == null) {
-            throw new Exception("La fila de la cabecera no se encontró en el índice especificado.");
-        }
-
-        Map<String, Integer> columnIndexMap = new HashMap<>();
-
-        // Leer la cabecera para obtener los índices de las columnas
-        for (Cell cell : headerRow) {
-            String cellValue = getCellValueAsString(cell);
-            log.debug("cellValue: {}", cellValue);
-            switch (cellValue) {
-                case "Catálogo":
-                    columnIndexMap.put("catalogo", cell.getColumnIndex());
-                    break;
-                case "0":
-                    columnIndexMap.put("origen", cell.getColumnIndex());
-                    break;
-                case "s/IVA":
-                    columnIndexMap.put("sinIva", cell.getColumnIndex());
-                    break;
-                case "D":
-                    columnIndexMap.put("descuento", cell.getColumnIndex());
-                    break;
-                case "Denominación":
-                    columnIndexMap.put("denominacion", cell.getColumnIndex());
-                    break;
-                case "Fecha":
-                    columnIndexMap.put("fecha", cell.getColumnIndex());
-                    break;
-                case "Modelo":
-                    columnIndexMap.put("modelo", cell.getColumnIndex());
-                    break;
-                default:
-                    // Ignorar otras columnas
-                    break;
-            }
-        }
-
-        // Validar que se hayan encontrado todas las columnas necesarias
-        List<String> requiredColumns = Arrays.asList("catalogo", "origen", "sinIva", "descuento", "denominacion", "fecha", "modelo");
-        if (!columnIndexMap.keySet().containsAll(requiredColumns)) {
-            throw new Exception("El archivo Excel no contiene todas las columnas necesarias.");
-        }
-        // Obtener el número total de filas
-        int totalRows = sheet.getLastRowNum() + 1;
-
-        // Procesar desde la fila de inicio hasta el final
-        for (int rowIndex = startingRow; rowIndex < totalRows; rowIndex++) {
-            Row row = sheet.getRow(rowIndex);
-            if (row == null) {
-                continue; // Si la fila está vacía, saltarla
-            }
-
-            Articulo articulo;
-
-            try {
-                BigDecimal sinIvaUsd = getCellValueAsBigDecimal(row.getCell(columnIndexMap.get("sinIva")));
-                BigDecimal precioListaSinIva = sinIvaUsd.multiply(cotizacionDolar).setScale(2, RoundingMode.HALF_UP);
-
-                // Leer y asignar los valores a las propiedades del artículo
-                articulo = new Articulo.Builder()
-                        .codigoArticulo(getCellValueAsString(row.getCell(columnIndexMap.get("catalogo"))).trim() + ".I")
-                        .descripcion(cleanGarbage(getCellValueAsString(row.getCell(columnIndexMap.get("denominacion"))).trim()))
-                        .precioListaSinIvaUsd(sinIvaUsd)
-                        .precioListaSinIva(precioListaSinIva)
-                        .origen(getCellValueAsString(row.getCell(columnIndexMap.get("origen"))))
-                        .descuento(getCellValueAsString(row.getCell(columnIndexMap.get("descuento"))).trim())
-                        .fechaActualizacion(getCellValueAsOffsetDateTime(row.getCell(columnIndexMap.get("fecha"))))
-                        .modeloCamion(getCellValueAsString(row.getCell(columnIndexMap.get("modelo"))).trim())
-                        .build();
-
-                // Añadir el artículo a la lista
-                articulos.add(articulo);
-
-//                try {
-//                    log.debug("Articulo Procesado: {}", JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(common));
-//                } catch (JsonProcessingException e) {
-//                    log.error("Error al procesar el artículo: {}", e.getMessage());
-//                }
-
-            } catch (Exception e) {
-                // Manejar errores en el procesamiento de la fila
-                log.warn("Error al procesar la fila " + (rowIndex + 1) + ": " + e.getMessage());
-                // Puedes decidir si continuar o detener el procesamiento
-            }
-        }
-
-        // Cerrar el workbook
-        workbook.close();
-
-        return articulos;
+        static final List<String> DESCUENTOS_ESPECIALES = Arrays.asList("A", "9", "S", "7", "C", "6");
     }
 
-    // Métodos de utilidad para obtener los valores de las celdas
+    private ArticuloImportado createArticuloImportado(Articulo articulo, Importacion importacion, Cotizacion cotizacion, BigDecimal cotizacionDolar) {
+        return new ArticuloImportado.Builder()
+                .articuloId(articulo.getArticuloId())
+                .fecha(importacion.getFechaImportacion())
+                .codigoArticulo(articulo.getCodigoArticulo())
+                .descripcion(articulo.getDescripcion())
+                .precioListaSinIva(articulo.getPrecioListaSinIva())
+                .origen(articulo.getOrigen())
+                .descuento(articulo.getDescuento())
+                .fechaActualizacion(Objects.requireNonNull(articulo.getFechaActualizacion()))
+                .cotizacionId(cotizacion.getCotizacionId())
+                .valorUsd(cotizacionDolar)
+                .importacionId(importacion.getImportacionId())
+                .build();
+    }
 
-    private String getCellValueAsString(Cell cell) {
-        if (cell == null) return "";
-        switch (cell.getCellType()) {
-            case STRING:
-                return cell.getStringCellValue();
-            case NUMERIC:
-                if (DateUtil.isCellDateFormatted(cell)) {
-                    // Formatear fecha a string si es necesario
-                    return cell.getDateCellValue().toString();
-                } else {
-                    return BigDecimal.valueOf(cell.getNumericCellValue()).toPlainString();
-                }
-            case BOOLEAN:
-                return Boolean.toString(cell.getBooleanCellValue());
-            case FORMULA:
-                // Evaluar la fórmula si es necesario
-                return cell.getCellFormula();
-            case BLANK:
-            case _NONE:
-            case ERROR:
-            default:
-                return "";
+    private Optional<Cotizacion> findOrCreateCotizacion(OffsetDateTime fecha, BigDecimal cotizacionDolar) {
+        try {
+            return Optional.of(cotizacionService.findByFecha(fecha));
+        } catch (CotizacionException e) {
+            Cotizacion nuevaCotizacion = new Cotizacion.Builder()
+                    .fecha(fecha)
+                    .usdVenta(cotizacionDolar)
+                    .build();
+            return Optional.of(cotizacionService.add(nuevaCotizacion));
         }
     }
 
-    private BigDecimal getCellValueAsBigDecimal(Cell cell) {
-        if (cell == null) return BigDecimal.ZERO;
-        switch (cell.getCellType()) {
-            case NUMERIC:
-                return BigDecimal.valueOf(cell.getNumericCellValue());
-            case STRING:
-                String value = cell.getStringCellValue().replace(",", ".").trim();
-                try {
-                    return new BigDecimal(value);
-                } catch (NumberFormatException e) {
-                    return BigDecimal.ZERO;
-                }
-            default:
-                return BigDecimal.ZERO;
-        }
-    }
-
-    private OffsetDateTime getCellValueAsOffsetDateTime(Cell cell) {
-        if (cell == null) return null;
-        if (cell.getCellType() == CellType.NUMERIC && DateUtil.isCellDateFormatted(cell)) {
-            return cell.getDateCellValue().toInstant().atOffset(ZoneOffset.UTC);
-        }
-        return null;
-    }
-
-    // Método para limpiar caracteres no deseados de una cadena
-    private String cleanGarbage(String input) {
-        // Implementa la lógica de limpieza según tus necesidades
-        return input.replaceAll("[^\\p{Print}]", "");
+    @Transactional
+    public void processBatch(List<Articulo> batch, Importacion importacion, Cotizacion cotizacion, 
+                            BigDecimal cotizacionDolar, Proveedor proveedor) {
+        // Procesar el lote en una única transacción
     }
 }

--- a/src/main/java/com/pys/common/java/specification/ProveedorSpecifications.java
+++ b/src/main/java/com/pys/common/java/specification/ProveedorSpecifications.java
@@ -1,0 +1,47 @@
+package com.pys.common.java.specification;
+
+import com.pys.common.kotlin.model.Proveedor;
+import org.springframework.data.jpa.domain.Specification;
+import jakarta.persistence.criteria.Predicate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ProveedorSpecifications {
+
+    public static Specification<Proveedor> searchByCadena(String cadena) {
+        return (root, query, criteriaBuilder) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            // Concatenación de campos y comparación con LIKE
+            Predicate likePredicate = criteriaBuilder.like(
+                criteriaBuilder.concat(
+                    criteriaBuilder.concat(
+                        criteriaBuilder.coalesce(root.get("cuit"), ""),
+                        " "
+                    ),
+                    criteriaBuilder.concat(
+                        criteriaBuilder.coalesce(root.get("razonSocial"), ""),
+                        criteriaBuilder.concat(
+                            " ",
+                            criteriaBuilder.coalesce(root.get("nombreFantasia"), "")
+                        )
+                    )
+                ),
+                "%" + cadena.toLowerCase() + "%"
+            );
+
+            // Asegurar que razonSocial no esté vacío
+            Predicate razonSocialNotEmpty = criteriaBuilder.notEqual(
+                root.get("razonSocial"), ""
+            );
+
+            predicates.add(likePredicate);
+            predicates.add(razonSocialNotEmpty);
+
+            // Ordenar por razonSocial
+            query.orderBy(criteriaBuilder.asc(root.get("razonSocial")));
+
+            return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+} 

--- a/src/main/java/com/pys/common/kotlin/exception/ArticuloAliasException.kt
+++ b/src/main/java/com/pys/common/kotlin/exception/ArticuloAliasException.kt
@@ -1,0 +1,5 @@
+package com.pys.common.kotlin.exception
+
+class ArticuloAliasException : RuntimeException {
+    constructor(alias: String) : super("ArticuloAlias no encontrado con alias $alias")
+}

--- a/src/main/java/com/pys/common/kotlin/exception/CotizacionException.kt
+++ b/src/main/java/com/pys/common/kotlin/exception/CotizacionException.kt
@@ -2,4 +2,6 @@ package com.pys.common.kotlin.exception
 
 import java.time.OffsetDateTime
 
-class CotizacionException(fecha: OffsetDateTime) : RuntimeException("Cotizacion no encontrada para fecha $fecha")
+class CotizacionException : RuntimeException {
+    constructor(fecha: OffsetDateTime) : super("Cotizacion no encontrada para fecha $fecha")
+}

--- a/src/main/java/com/pys/common/kotlin/exception/ProveedorException.kt
+++ b/src/main/java/com/pys/common/kotlin/exception/ProveedorException.kt
@@ -1,3 +1,12 @@
 package com.pys.common.kotlin.exception
 
-class ProveedorException(proveedorId: Long) : RuntimeException("Proveedor no encontrado con id $proveedorId")
+import java.util.UUID
+
+class ProveedorException : RuntimeException {
+
+    constructor() : super("Ningún proveedor encontrado")
+    constructor(proveedorId: UUID) : super("Proveedor no encontrado con id $proveedorId")
+    constructor(proveedorIdNegocio: Long) : super("Proveedor no encontrado con idNegocio $proveedorIdNegocio")
+    constructor(cuit: String) : super("Proveedor no encontrado con cuit $cuit")
+
+}

--- a/src/main/java/com/pys/common/kotlin/model/Articulo.kt
+++ b/src/main/java/com/pys/common/kotlin/model/Articulo.kt
@@ -13,14 +13,15 @@ import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
 import java.math.BigDecimal
 import java.time.OffsetDateTime
+import java.util.UUID
 
 @Entity
 @Table(uniqueConstraints = [UniqueConstraint(columnNames = ["codigoArticulo"])])
 data class Articulo(
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var articuloId: Long? = null,
+    @GeneratedValue(strategy = GenerationType.UUID)
+    var articuloId: UUID? = null,
 
     var codigoArticulo: String = "",
     var descripcion: String = "",
@@ -40,14 +41,14 @@ data class Articulo(
     var fechaActualizacion: OffsetDateTime? = null,
     var origen: String = "",
     var descuento: String = "",
-    var proveedorId: Long? = null,
+    var proveedorId: UUID? = null,
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
     var ultimaCompra: OffsetDateTime? = null,
     var marca: String = "",
     var catalogo: String = "",
     var precioListaSinIvaUsd: BigDecimal = BigDecimal("0.00"),
-    var cotizacionId: Long? = null,
+    var cotizacionId: UUID? = null,
 
     @OneToOne(optional = true)
     @JoinColumn(name = "proveedorId", insertable = false, updatable = false)
@@ -60,7 +61,7 @@ data class Articulo(
 ) : Auditable() {
 
     class Builder {
-        private var articuloId: Long? = null
+        private var articuloId: UUID? = null
         private var codigoArticulo: String = ""
         private var descripcion: String = ""
         private var precioVentaConIva: BigDecimal = BigDecimal("0.00")
@@ -75,15 +76,15 @@ data class Articulo(
         private var fechaActualizacion: OffsetDateTime? = null
         private var origen: String = ""
         private var descuento: String = ""
-        private var proveedorId: Long? = null
+        private var proveedorId: UUID? = null
         private var ultimaCompra: OffsetDateTime? = null
         private var marca: String = ""
         private var catalogo: String = ""
         private var precioListaSinIvaUsd: BigDecimal = BigDecimal("0.00")
-        private var cotizacionId: Long? = null
+        private var cotizacionId: UUID? = null
         private var proveedor: Proveedor? = null
 
-        fun articuloId(articuloId: Long?) = apply { this.articuloId = articuloId }
+        fun articuloId(articuloId: UUID?) = apply { this.articuloId = articuloId }
         fun codigoArticulo(codigoArticulo: String) = apply { this.codigoArticulo = codigoArticulo }
         fun descripcion(descripcion: String) = apply { this.descripcion = descripcion }
         fun precioVentaConIva(precioVentaConIva: BigDecimal) = apply { this.precioVentaConIva = precioVentaConIva }
@@ -98,12 +99,12 @@ data class Articulo(
         fun fechaActualizacion(fechaActualizacion: OffsetDateTime?) = apply { this.fechaActualizacion = fechaActualizacion }
         fun origen(origen: String) = apply { this.origen = origen }
         fun descuento(descuento: String) = apply { this.descuento = descuento }
-        fun proveedorId(proveedorId: Long?) = apply { this.proveedorId = proveedorId }
+        fun proveedorId(proveedorId: UUID?) = apply { this.proveedorId = proveedorId }
         fun ultimaCompra(ultimaCompra: OffsetDateTime?) = apply { this.ultimaCompra = ultimaCompra }
         fun marca(marca: String) = apply { this.marca = marca }
         fun catalogo(catalogo: String) = apply { this.catalogo = catalogo }
         fun precioListaSinIvaUsd(precioListaSinIvaUsd: BigDecimal) = apply { this.precioListaSinIvaUsd = precioListaSinIvaUsd }
-        fun cotizacionId(cotizacionId: Long?) = apply { this.cotizacionId = cotizacionId }
+        fun cotizacionId(cotizacionId: UUID?) = apply { this.cotizacionId = cotizacionId }
         fun proveedor(proveedor: Proveedor?) = apply { this.proveedor = proveedor }
 
         fun build() = Articulo(

--- a/src/main/java/com/pys/common/kotlin/model/ArticuloAlias.kt
+++ b/src/main/java/com/pys/common/kotlin/model/ArticuloAlias.kt
@@ -10,17 +10,18 @@ import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
 import java.math.BigDecimal
+import java.util.UUID
 
 @Entity
 @Table(uniqueConstraints = [UniqueConstraint(columnNames = ["alias"])])
 data class ArticuloAlias(
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val articuloAliasId: Long? = null,
-    val articuloId: Long? = null,
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val articuloAliasId: UUID? = null,
+    val articuloId: UUID? = null,
     val alias: String = "",
-    val proveedorId: Long? = null,
+    val proveedorId: UUID? = null,
     val precioCompra: BigDecimal = BigDecimal("0.00"),
 
     @OneToOne(optional = true)
@@ -34,18 +35,18 @@ data class ArticuloAlias(
 ) : Auditable() {
 
     class Builder {
-        private var articuloAliasId: Long? = null
-        private var articuloId: Long? = null
+        private var articuloAliasId: UUID? = null
+        private var articuloId: UUID? = null
         private var alias: String = ""
-        private var proveedorId: Long? = null
+        private var proveedorId: UUID? = null
         private var precioCompra: BigDecimal = BigDecimal("0.00")
         private var articulo: Articulo? = null
         private var proveedor: Proveedor? = null
 
-        fun articuloAliasId(articuloAliasId: Long?) = apply { this.articuloAliasId = articuloAliasId }
-        fun articuloId(articuloId: Long?) = apply { this.articuloId = articuloId }
+        fun articuloAliasId(articuloAliasId: UUID?) = apply { this.articuloAliasId = articuloAliasId }
+        fun articuloId(articuloId: UUID?) = apply { this.articuloId = articuloId }
         fun alias(alias: String) = apply { this.alias = alias }
-        fun proveedorId(proveedorId: Long?) = apply { this.proveedorId = proveedorId }
+        fun proveedorId(proveedorId: UUID?) = apply { this.proveedorId = proveedorId }
         fun precioCompra(precioCompra: BigDecimal) = apply { this.precioCompra = precioCompra }
         fun articulo(articulo: Articulo?) = apply { this.articulo = articulo }
         fun proveedor(proveedor: Proveedor?) = apply { this.proveedor = proveedor }

--- a/src/main/java/com/pys/common/kotlin/model/ArticuloImportado.kt
+++ b/src/main/java/com/pys/common/kotlin/model/ArticuloImportado.kt
@@ -10,14 +10,16 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToOne
 import java.math.BigDecimal
 import java.time.OffsetDateTime
+import java.util.UUID
 
 @Entity
 data class ArticuloImportado(
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val articuloImportadoId: Long? = null,
-    val articuloId: Long? = null,
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val articuloImportadoId: UUID? = null,
+
+    val articuloId: UUID? = null,
     val fecha: OffsetDateTime? = null,
     val codigoArticulo: String? = null,
     val descripcion: String = "",
@@ -27,9 +29,9 @@ data class ArticuloImportado(
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
     val fechaActualizacion: OffsetDateTime,
-    val cotizacionId: Long? = null,
+    val cotizacionId: UUID? = null,
     val valorUsd: BigDecimal = BigDecimal("0.00"),
-    val importacionId: Long? = null,
+    val importacionId: UUID? = null,
 
     @OneToOne(optional = true)
     @JoinColumn(name = "artiuloId", insertable = false, updatable = false)
@@ -46,8 +48,8 @@ data class ArticuloImportado(
 ) : Auditable() {
 
     class Builder {
-        private var articuloImportadoId: Long? = null
-        private var articuloId: Long? = null
+        private var articuloImportadoId: UUID? = null
+        private var articuloId: UUID? = null
         private var fecha: OffsetDateTime? = null
         private var codigoArticulo: String? = null
         private var descripcion: String = ""
@@ -55,15 +57,15 @@ data class ArticuloImportado(
         private var origen: String = ""
         private var descuento: String = ""
         private var fechaActualizacion: OffsetDateTime = OffsetDateTime.now()
-        private var cotizacionId: Long? = null
+        private var cotizacionId: UUID? = null
         private var valorUsd: BigDecimal = BigDecimal("0.00")
-        private var importacionId: Long? = null
+        private var importacionId: UUID? = null
         private var articulo: Articulo? = null
         private var cotizacion: Cotizacion? = null
         private var importacion: Importacion? = null
 
-        fun articuloImportadoId(articuloImportadoId: Long?) = apply { this.articuloImportadoId = articuloImportadoId }
-        fun articuloId(articuloId: Long?) = apply { this.articuloId = articuloId }
+        fun articuloImportadoId(articuloImportadoId: UUID?) = apply { this.articuloImportadoId = articuloImportadoId }
+        fun articuloId(articuloId: UUID?) = apply { this.articuloId = articuloId }
         fun fecha(fecha: OffsetDateTime?) = apply { this.fecha = fecha }
         fun codigoArticulo(codigoArticulo: String?) = apply { this.codigoArticulo = codigoArticulo }
         fun descripcion(descripcion: String) = apply { this.descripcion = descripcion }
@@ -71,9 +73,9 @@ data class ArticuloImportado(
         fun origen(origen: String) = apply { this.origen = origen }
         fun descuento(descuento: String) = apply { this.descuento = descuento }
         fun fechaActualizacion(fechaActualizacion: OffsetDateTime) = apply { this.fechaActualizacion = fechaActualizacion }
-        fun cotizacionId(cotizacionId: Long?) = apply { this.cotizacionId = cotizacionId }
+        fun cotizacionId(cotizacionId: UUID?) = apply { this.cotizacionId = cotizacionId }
         fun valorUsd(valorUsd: BigDecimal) = apply { this.valorUsd = valorUsd }
-        fun importacionId(importacionId: Long?) = apply { this.importacionId = importacionId }
+        fun importacionId(importacionId: UUID?) = apply { this.importacionId = importacionId }
         fun articulo(articulo: Articulo?) = apply { this.articulo = articulo }
         fun cotizacion(cotizacion: Cotizacion?) = apply { this.cotizacion = cotizacion }
         fun importacion(importacion: Importacion?) = apply { this.importacion = importacion }

--- a/src/main/java/com/pys/common/kotlin/model/Cotizacion.kt
+++ b/src/main/java/com/pys/common/kotlin/model/Cotizacion.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
 import java.math.BigDecimal
 import java.time.OffsetDateTime
+import java.util.UUID
 
 @Entity
 @Table(uniqueConstraints = [
@@ -18,8 +19,8 @@ import java.time.OffsetDateTime
 data class Cotizacion(
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var cotizacionId: Long? = null,
+    @GeneratedValue(strategy = GenerationType.UUID)
+    var cotizacionId: UUID? = null,
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
     var fecha: OffsetDateTime? = null,
@@ -29,12 +30,12 @@ data class Cotizacion(
 ) : Auditable() {
 
     class Builder {
-        private var cotizacionId: Long? = null
+        private var cotizacionId: UUID? = null
         private var fecha: OffsetDateTime? = null
         private var usdCompra: BigDecimal = BigDecimal("0.00")
         private var usdVenta: BigDecimal = BigDecimal("0.00")
 
-        fun cotizacionId(cotizacionId: Long?) = apply { this.cotizacionId = cotizacionId }
+        fun cotizacionId(cotizacionId: UUID?) = apply { this.cotizacionId = cotizacionId }
         fun fecha(fecha: OffsetDateTime?) = apply { this.fecha = fecha }
         fun usdCompra(usdCompra: BigDecimal) = apply { this.usdCompra = usdCompra }
         fun usdVenta(usdVenta: BigDecimal) = apply { this.usdVenta = usdVenta }

--- a/src/main/java/com/pys/common/kotlin/model/Importacion.kt
+++ b/src/main/java/com/pys/common/kotlin/model/Importacion.kt
@@ -7,13 +7,14 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import java.time.OffsetDateTime
+import java.util.UUID
 
 @Entity
 data class Importacion(
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val importacionId: Long? = null,
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val importacionId: UUID? = null,
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
     val fechaImportacion: OffsetDateTime? = null
@@ -21,10 +22,10 @@ data class Importacion(
 ) : Auditable() {
 
     class Builder {
-        private var importacionId: Long? = null
+        private var importacionId: UUID? = null
         private var fechaImportacion: OffsetDateTime? = null
 
-        fun importacionId(importacionId: Long?) = apply { this.importacionId = importacionId }
+        fun importacionId(importacionId: UUID?) = apply { this.importacionId = importacionId }
         fun fechaImportacion(fechaImportacion: OffsetDateTime?) = apply { this.fechaImportacion = fechaImportacion }
 
         fun build() = Importacion(

--- a/src/main/java/com/pys/common/kotlin/model/Negocio.kt
+++ b/src/main/java/com/pys/common/kotlin/model/Negocio.kt
@@ -14,6 +14,7 @@ data class Negocio(
     var sucursalId: Int? = null,
     var databaseName: String? = null,
     var databaseIp: String? = null,
+    var databasePort: Int = 0,
     var databaseDsn: String? = null,
     var databaseUid: String? = null,
     var databasePwd: String? = null,

--- a/src/main/java/com/pys/common/kotlin/model/Proveedor.kt
+++ b/src/main/java/com/pys/common/kotlin/model/Proveedor.kt
@@ -7,14 +7,16 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
+import java.util.UUID
 
 @Entity
 @Table(uniqueConstraints = [UniqueConstraint(columnNames = ["cuit"])])
 data class Proveedor(
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val proveedorId: Long? = null,
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val proveedorId: UUID? = null,
+    var proveedorIdNegocio: Long? = null,
     val razonSocial: String = "",
     val nombreFantasia: String = "",
     val cuit: String = "",
@@ -24,7 +26,7 @@ data class Proveedor(
     val telefono: String = "",
     val fax: String = "",
     val email: String = "",
-    val posicionIva: Short = 0,
+    val posicionIva: Int = 0,
     val celular: String = "",
     val ingresosBrutos: String = "",
     val contacto: String = "",
@@ -33,7 +35,8 @@ data class Proveedor(
 ) : Auditable() {
 
     class Builder {
-        private var proveedorId: Long? = null
+        private var proveedorId: UUID? = null
+        private var proveedorIdNegocio: Long? = null
         private var razonSocial: String = ""
         private var nombreFantasia: String = ""
         private var cuit: String = ""
@@ -43,13 +46,14 @@ data class Proveedor(
         private var telefono: String = ""
         private var fax: String = ""
         private var email: String = ""
-        private var posicionIva: Short = 0
+        private var posicionIva: Int = 0
         private var celular: String = ""
         private var ingresosBrutos: String = ""
         private var contacto: String = ""
         private var observaciones: String = ""
 
-        fun proveedorId(proveedorId: Long?) = apply { this.proveedorId = proveedorId }
+        fun proveedorId(proveedorId: UUID?) = apply { this.proveedorId = proveedorId }
+        fun proveedorIdNegocio(proveedorIdNegocio: Long?) = apply { this.proveedorIdNegocio = proveedorIdNegocio }
         fun razonSocial(razonSocial: String) = apply { this.razonSocial = razonSocial }
         fun nombreFantasia(nombreFantasia: String) = apply { this.nombreFantasia = nombreFantasia }
         fun cuit(cuit: String) = apply { this.cuit = cuit }
@@ -59,14 +63,14 @@ data class Proveedor(
         fun telefono(telefono: String) = apply { this.telefono = telefono }
         fun fax(fax: String) = apply { this.fax = fax }
         fun email(email: String) = apply { this.email = email }
-        fun posicionIva(posicionIva: Short) = apply { this.posicionIva = posicionIva }
+        fun posicionIva(posicionIva: Int) = apply { this.posicionIva = posicionIva }
         fun celular(celular: String) = apply { this.celular = celular }
         fun ingresosBrutos(ingresosBrutos: String) = apply { this.ingresosBrutos = ingresosBrutos }
         fun contacto(contacto: String) = apply { this.contacto = contacto }
         fun observaciones(observaciones: String) = apply { this.observaciones = observaciones }
 
         fun build() = Proveedor(
-            proveedorId, razonSocial, nombreFantasia, cuit, domicilio, localidad, provincia, telefono, fax, email,
+            proveedorId, proveedorIdNegocio, razonSocial, nombreFantasia, cuit, domicilio, localidad, provincia, telefono, fax, email,
             posicionIva, celular, ingresosBrutos, contacto, observaciones
         )
     }

--- a/src/main/java/com/pys/common/kotlin/model/audit/Auditable.kt
+++ b/src/main/java/com/pys/common/kotlin/model/audit/Auditable.kt
@@ -19,4 +19,5 @@ open class Auditable {
     @field:LastModifiedDate
     @Column(name = "updated")
     open var updated: LocalDateTime? = null
+
 }

--- a/src/main/java/com/pys/common/kotlin/repository/ArticuloAliasRepository.kt
+++ b/src/main/java/com/pys/common/kotlin/repository/ArticuloAliasRepository.kt
@@ -3,7 +3,11 @@ package com.pys.common.kotlin.repository
 import com.pys.common.kotlin.model.ArticuloAlias
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import java.util.Optional
 
 @Repository
 interface ArticuloAliasRepository : JpaRepository<ArticuloAlias, Long> {
+
+    fun findByAlias(alias: String): Optional<ArticuloAlias?>?
+
 }

--- a/src/main/java/com/pys/common/kotlin/repository/ArticuloRepository.kt
+++ b/src/main/java/com/pys/common/kotlin/repository/ArticuloRepository.kt
@@ -8,7 +8,7 @@ import java.util.Optional
 @Repository
 interface ArticuloRepository : JpaRepository<Articulo, Long> {
 
-    fun findAllByCodigoArticuloIn(codigoArticulos: MutableList<String>): MutableList<Articulo?>?
+    fun findAllByCodigoArticuloIn(codigoArticulos: MutableList<String>): List<Articulo?>?
 
     fun findByCodigoArticulo(codigoArticulo: String): Optional<Articulo?>?
 

--- a/src/main/java/com/pys/common/kotlin/repository/CotizacionRepository.kt
+++ b/src/main/java/com/pys/common/kotlin/repository/CotizacionRepository.kt
@@ -5,9 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.time.OffsetDateTime
 import java.util.Optional
+import java.util.UUID
 
 @Repository
-interface CotizacionRepository : JpaRepository<Cotizacion, Long> {
+interface CotizacionRepository : JpaRepository<Cotizacion, UUID> {
 
     fun findByFecha(fechaImportacion: OffsetDateTime): Optional<Cotizacion?>?
 

--- a/src/main/java/com/pys/common/kotlin/repository/ProveedorRepository.kt
+++ b/src/main/java/com/pys/common/kotlin/repository/ProveedorRepository.kt
@@ -1,13 +1,31 @@
 package com.pys.common.kotlin.repository
 
 import com.pys.common.kotlin.model.Proveedor
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.stereotype.Repository
 import java.util.Optional
+import java.util.UUID
 
 @Repository
-interface ProveedorRepository : JpaRepository<Proveedor, Long> {
+interface ProveedorRepository : JpaRepository<Proveedor, UUID>, JpaSpecificationExecutor<Proveedor> {
 
-    fun findByProveedorId(proveedorId: Long): Optional<Proveedor?>?
+    fun findAllByOrderByRazonSocial(): List<Proveedor>
+
+    fun findAllByOrderByRazonSocial(pageable: Pageable): Page<Proveedor>
+
+    fun findAllByRazonSocialContainsIgnoreCaseOrderByRazonSocial(razonSocial: String, pageable: Pageable): Page<Proveedor>
+
+    fun findByProveedorId(proveedorId: UUID): Optional<Proveedor?>?
+
+    fun findByProveedorIdNegocio(proveedorIdNegocio: Long): Optional<Proveedor?>?
+
+    fun findTop1ByOrderByProveedorIdNegocioDesc(): Optional<Proveedor?>?
+
+    fun findByCuit(cuit: String): Optional<Proveedor?>?
+
+    fun deleteByProveedorId(proveedorId: UUID)
 
 }

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -44,3 +44,9 @@ logging:
       hibernate:
         SQL: ${app.logging}
       springframework.cloud.config: ${app.logging}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"


### PR DESCRIPTION
# feat(proveedor): migrar a UUID y mejorar gestión de proveedores

## Descripción
Este PR implementa la migración de IDs numéricos a UUID para la entidad Proveedor, mejorando la escalabilidad y unicidad de los identificadores. También se incluyen mejoras en la gestión de proveedores y actualizaciones en los repositorios.

## Cambios realizados
- [x] Migrar `proveedorId` de `Long` a `UUID`
- [x] Agregar campo `proveedorIdNegocio` para mantener compatibilidad
- [x] Actualizar repositorios con nuevas consultas y soporte para paginación
- [x] Implementar `JpaSpecificationExecutor` en `ProveedorRepository`
- [x] Actualizar servicios y controladores relacionados
- [x] Agregar documentación en README y CHANGELOG
- [x] Habilitar endpoints de gestión en `bootstrap.yml`

## Impacto potencial
- [x] Migración de base de datos requerida (cambio de tipo de ID)
- [x] Actualización de servicios que consuman la API de proveedores
- [x] Cambios en las respuestas de la API (nuevos campos, formato de IDs)

## Verificación
1. Ejecutar migración de base de datos
2. Probar CRUD de proveedores
3. Verificar búsquedas paginadas
4. Validar compatibilidad con servicios existentes

## Notas adicionales
- Resuelve #10
- Requiere actualización de la documentación de la API
- Se recomienda realizar pruebas de carga por el cambio de tipo de ID
